### PR TITLE
Edit doc landing page and add one additional doc page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,18 +19,31 @@ GitHub integration is made through the GitHub app interface and the checks API (
 which allows results to be presented directly as inline annotations instead of
 a pass/fail status report.
 
-Precaution currently supports analysis of python files via Bandit and go files via Gosec. New languages may be added in future.
+Precaution currently supports analysis of:
+* Go files via [Gosec](https://github.com/securego/gosec)
+* JavaScript and TypeScript via [TSLint](https://github.com/palantir/tslint) and [tslint-config-security](https://github.com/webschik/tslint-config-security)
+* Python files via [Bandit](https://github.com/PyCQA/bandit)
+
+New languages may be added in future, please file an [issue](https://github.com/vmware/precaution/issues) for your language/linter of choice.
 
 * Documentation: [vmware/precaution/docs](https://vmware.github.io/precaution/)
 * Source: [vmware/precaution](https://github.com/vmware/precaution)
-* Bugs: [vmware/precaution/issues](https://github.com/vmware/precaution/issues)
+<!-- * Bugs: [vmware/precaution/issues](https://github.com/vmware/precaution/issues) -->
 
-## Additional documentation
+## Try Precaution
+
+Check out the several sections and you can continue with your project but with it being secure.
 
 - [Initial setup](initial_setup.md)
 - [Setting up Precaution as branch protection rule](branch_protection_rule.md)
 - [False positives and how to handle them](false_positivies.md)
+
+## Contributers documentation
+
+If you are enthusiastic about Precaution and want to improve it don't be concerned. Anyone can contribute, whether you’re new to the project or not.
+
+- Bugs: [vmware/precaution/issues](https://github.com/vmware/precaution/issues)
 - [Setting up a manual deployment](manual_deployment.md)
-- [Building this documentation locally](local_docs_build.md)
 - [Debugging with VSCode](local_development.md)
 - [Architecture](architecture.md)
+- [Building this documentation locally](local_docs_build.md)

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -3,6 +3,9 @@
     SPDX-License-Identifier: BSD-2-Clause
 -->
 
+# Debugging with VSCode
+
+
 Debugging recipes are available in the ```.vscode``` folder to help getting started with local debugging.
 
 Use the Jest configurations and set breakpoints to run the test suite step by step. The logging output

--- a/docs/redirect_github_webhooks.md
+++ b/docs/redirect_github_webhooks.md
@@ -1,0 +1,11 @@
+<!--
+    Copyright 2019 VMware, Inc.
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+
+# Redirect Github webhooks to your local machine
+
+This can be useful when you are doing development work on Precaution itself and need a simple solution to trace the webhooks sent by GitHub and receive them without exposing your app to the internet.
+
+Please refer to the [Probot documentation](https://probot.github.io/docs/development/#configuring-a-github-app) to direct GitHub webhooks to your local machine.
+


### PR DESCRIPTION
The new doc file is created to help developers to trace webhooks sent by Github
and receive them without exposing user app to the internet.

The docs/index.md has documentation both for contributers and users
and it is a good idea to have them regroup in to two groups for clarity.

Fix for issue https://github.com/vmware/precaution/issues/243.

Signed-off-by: Stanislava Georgieva stanislava.krasimirovaa@abv.bg